### PR TITLE
Response is exposed as argument in download request

### DIFF
--- a/www/helpers.js
+++ b/www/helpers.js
@@ -325,7 +325,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
 
   function injectFileEntryHandler(cb) {
     return function (response) {
-      cb(createFileEntry(response.file));
+      cb(createFileEntry(response.file), response);
     }
   }
 


### PR DESCRIPTION
Headers in download response are needed to find out attachment type. So, response is sent as an argument to the callback.